### PR TITLE
Relax spec_version check

### DIFF
--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -143,7 +143,7 @@ abstract class MetadataBase
                 'spec_version' => [
                     new NotBlank(),
                     new Type(['type' => 'string']),
-                    new Regex(['pattern' => '/^1(\.[0-9]){1,2}$/']),
+                    new Regex(['pattern' => '/^1(\.[0-9]+){1,2}$/']),
                 ],
             ] + static::getVersionConstraints(),
             'allowExtraFields' => true,

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -143,7 +143,7 @@ abstract class MetadataBase
                 'spec_version' => [
                     new NotBlank(),
                     new Type(['type' => 'string']),
-                    new Regex(['pattern' => '/^1\.[0-9]+\.[0-9]+$/']),
+                    new Regex(['pattern' => '/^1(\.[0-9]){1,2}$/']),
                 ],
             ] + static::getVersionConstraints(),
             'allowExtraFields' => true,

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -343,7 +343,10 @@ abstract class MetadataBaseTest extends TestCase
     {
         return [
             ['1', false],
-            ['1.0', false],
+            ['1.0', true],
+            ['1.9', true],
+            ['1.99', true],
+            ['1.999', true],
             ['2.00', false],
             ['1.0.a', false],
             ['1.0.1', true],


### PR DESCRIPTION
Based on the specification the spec_version has to be x.y.z sadly some implementations generates x.y entries.

More information can be found in https://github.com/theupdateframework/go-tuf/issues/206#issuecomment-1020213003